### PR TITLE
Proposal 1 : auto-generate PR when the helm chart related files are change

### DIFF
--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -1,16 +1,79 @@
 name: Release Charts
 
+# This workflow is used to release the sbombastic chart to the repository.
+# Trigger only:
+# - meerge into main branch && changes any file under charts/**
+
+# outputs:
+# - if the chart version is already released, it will update the chart version.
+#    - Create a PR to update the chart version.
+#    - If the PR is merged, it will create a new release.
+# - if the chart version is not released, it will create a new release.
+
+
+# Limitation:
+# - It will check with one charts now. (sbombastic)
+#   - if we want to separate the CRD as another chart, we need to change the workflow.
 on:
   push:
     branches:
       - main
+    paths:
+      - 'charts/**'
 
 concurrency:
   group: "release"
   cancel-in-progress: false
 
 jobs:
-  release:
+  detect-chart-update:
+    runs-on: ubuntu-latest
+    outputs:
+      version_bumped: ${{ steps.check_ver.outputs.version_bumped }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Fetch all tags
+        run: |
+          git fetch --no-tags --depth=1 origin
+          git fetch --tags
+      - name: Get latest sbombastic-chart tag
+        id: get_latest_tag
+        run: |
+          LATEST_TAG=$(git tag --list 'sbombastic-chart-*' | sort -V | tail -n1)
+          echo "latest_tag=$LATEST_TAG" >> $GITHUB_OUTPUT
+      - name: Show latest tag
+        run: echo "Latest chart release tag is ${{ steps.get_latest_tag.outputs.latest_tag }}"
+
+      - name: Compare Chart.yaml against that tag
+        id: check_ver
+        run: |
+          # current release a chart at once.
+          chart_version=$(helm show chart charts/sbombastic | yq -r '.version')
+
+          # check if the chart version is already released
+          OWNER=${{ github.repository_owner }}
+          REPO=sbombastic
+          if gh --repo $OWNER/$REPO release view sbombastic-chart-$chart_version; then
+            echo "version_bumped=true" >> $GITHUB_OUTPUT
+          else
+            echo "version_bumped=false" >> $GITHUB_OUTPUT
+          fi
+
+  bump-chart-version:
+    needs: [detect-chart-update]
+    if: needs.detect-chart-update.outputs.version_bumped == 'true'
+    uses: ./.github/workflows/update-charts.yml
+    permissions:
+      contents: write # for updatecli to update the repository
+      pull-requests: write # for updatecli to create a PR
+    secrets: inherit
+
+  release-chart:
+    needs: [detect-chart-update]
+    if: needs.detect-chart-update.outputs.version_bumped == 'false'
     permissions:
       contents: write # chart-releaser needs to release the charts to the repository
     runs-on: ubuntu-latest
@@ -34,7 +97,5 @@ jobs:
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
-        with:
-          config: cr.yaml
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Description
This workflow is used to release the sbombastic chart to the repository.
**Trigger only**
 - meerge into main branch
 - changes any file under charts/**

**outputs**
- if the chart version is already released, it will update the chart version.
    - Create a PR to update the chart version.
    - If the PR is merged, it will create a new release.
- if the chart version is not released, it will create a new release.


Limitation:
 - It will check with one charts now. (sbombastic)
    - if we want to separate the CRD as another chart, we need to change the workflow.
